### PR TITLE
fix: remove confusing note from system prompt to prevent model hallucinations

### DIFF
--- a/whai/defaults/system_prompt.txt
+++ b/whai/defaults/system_prompt.txt
@@ -74,6 +74,4 @@ This uses:
 - tail -n 5: Show the 5 largest entries
 - awk '{{print $1 "\t" $2}}': Format output as size (tab) path
 - numfmt --to=iec-i --suffix=B --field=1,1: Convert sizes to human-readable format (KiB, MiB, etc.)
-
-[Note: Use the execute_shell tool to run this command. The tool expects the command as a string in the "command" parameter.]
 ----------------------------------------


### PR DESCRIPTION
Fix #4

I have fixed the issue where the LLM would output the command execution instruction as text instead of executing the tool.

The root cause was a "Note" in the system prompt's example section that explicitly wrote out the instruction [Note: Use the execute_shell tool...]. Some models were interpreting this as part of the desired text output rather than a meta-instruction.

I have removed the misleading note from whai/defaults/system_prompt.txt. The BEHAVIOR section of the system prompt already clearly instructs the model to "ALWAYS use the execute_shell tool" and "Do NOT ask permission", which is sufficient for correct operation without the confusing example text.

Let me know what you think abotu this approach